### PR TITLE
explicitely match on /data to ensure we get triggered

### DIFF
--- a/lib/cards/contrib/triggered-action-integration-outreach-mirror-event.ts
+++ b/lib/cards/contrib/triggered-action-integration-outreach-mirror-event.ts
@@ -16,11 +16,14 @@ export const triggeredActionIntegrationOutreachMirrorEvent: ContractDefinition =
 			schedule: 'sync',
 			filter: {
 				type: 'object',
-				required: ['type'],
+				required: ['type', 'data'],
 				properties: {
 					type: {
 						type: 'string',
 						const: 'contact@1.0.0',
+					},
+					data: {
+						type: 'object',
 					},
 				},
 			},


### PR DESCRIPTION
this is necessary after the change of triggered actions to only run when required data is changed

Change-type: patch
Signed-off-by: Martin Rauscher <martin@balena.io>